### PR TITLE
Fix 'app:spb_color=#fff' color setting with SmoothProgressBar

### DIFF
--- a/library/src/main/java/fr/castorflex/android/smoothprogressbar/SmoothProgressBar.java
+++ b/library/src/main/java/fr/castorflex/android/smoothprogressbar/SmoothProgressBar.java
@@ -77,7 +77,10 @@ public class SmoothProgressBar extends ProgressBar {
                 .reversed(reversed);
 
         if (strSpeed != null) builder.speed(Float.parseFloat(strSpeed));
-        if(colors != null && colors.length > 0) builder.colors(colors);
+        if(colors != null && colors.length > 0)
+            builder.colors(colors);
+        else
+            builder.color(color);
 
         setIndeterminateDrawable(builder.build());
     }


### PR DESCRIPTION
Setting the progress color via XML is not working, SmoothProgressBar is ignoring the 'color' attribute.

Signed-off-by: Lucio Maciel luciofm@gmail.com
