### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
     package="fr.castorflex.android.smoothprogressbar">
-
-    <application/>
-
+   
 </manifest>


### PR DESCRIPTION
We are not using <application> tag so we don't need to close it also. That's why I remove this.
