### PR TITLE
- setMatrix method for CircularProgressBar

### DIFF
--- a/library-circular/src/main/java/fr.castorflex.android.circularprogressbar/CircularProgressBar.java
+++ b/library-circular/src/main/java/fr.castorflex.android.circularprogressbar/CircularProgressBar.java
@@ -3,6 +3,7 @@ package fr.castorflex.android.circularprogressbar;
 import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
+import android.graphics.Matrix;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.widget.ProgressBar;
@@ -77,5 +78,11 @@ public class CircularProgressBar extends ProgressBar {
 
   public void progressiveStop(CircularProgressDrawable.OnEndListener listener) {
     checkIndeterminateDrawable().progressiveStop(listener);
+  }
+
+  /** Sets a matrix object to apply on the drawable */
+  public void setMatrix(Matrix matrix) {
+    CircularProgressDrawable drawable = (CircularProgressDrawable) getIndeterminateDrawable();
+    drawable.setMatrix(matrix);
   }
 }

--- a/library-circular/src/main/java/fr.castorflex.android.circularprogressbar/CircularProgressDrawable.java
+++ b/library-circular/src/main/java/fr.castorflex.android.circularprogressbar/CircularProgressDrawable.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.ColorFilter;
+import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.PixelFormat;
 import android.graphics.Rect;
@@ -69,6 +70,9 @@ public class CircularProgressDrawable extends Drawable
   private int          mMaxSweepAngle;
   private boolean      mFirstSweepAnimation;
 
+  /** The matrix object to apply on the canvas */
+  private Matrix mMatrix;
+
   private CircularProgressDrawable(int[] colors,
                                    float borderWidth,
                                    float sweepSpeed,
@@ -117,6 +121,9 @@ public class CircularProgressDrawable extends Drawable
       float newSweepAngle = sweepAngle * mCurrentEndRatio;
       startAngle = (startAngle + (sweepAngle - newSweepAngle)) % 360;
       sweepAngle = newSweepAngle;
+    }
+    if(mMatrix != null) {
+      canvas.concat(mMatrix);
     }
     canvas.drawArc(fBounds, startAngle, sweepAngle, false, mPaint);
   }
@@ -381,6 +388,22 @@ public class CircularProgressDrawable extends Drawable
   private void setEndRatio(float ratio) {
     mCurrentEndRatio = ratio;
     invalidateSelf();
+  }
+
+  /**
+   * Returns a matrix object that associated with the canvas
+   * @return
+   */
+  public Matrix getMatrix() {
+    return mMatrix;
+  }
+
+  /**
+   * Sets a matrix object that associated with the canvas
+   * @param matrix
+   */
+  public void setMatrix(Matrix matrix) {
+    this.mMatrix = matrix;
   }
 
   public static class Builder {


### PR DESCRIPTION
Add `setMatrix(Matrix)` method for CircularProgressBar, for better quality use software layer
This example snippet set isometric matrix on the CircularProgressBar
```java
@Override
public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
...
circularProgressBar.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
            @Override
            public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
                Matrix matrix = getIsometricMatrix(circularProgressBar.getWidth(), circularProgressBar.getHeight());
                circularProgressBar.setMatrix(matrix);
                circularProgressBar.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
            }
        });
...
}

public static Matrix getIsometricMatrix(float w, float h) {
	Matrix matrix = new Matrix();
	final float pX = w / 2f;
	final float pY = h / 2f;
	final Camera camera = new Camera();
	camera.save();
	camera.rotateX(45);
	camera.rotateY(0);
	camera.rotateZ(0);
	camera.getMatrix(matrix);
	camera.restore();
	matrix.preTranslate(-pX,-pY);
	matrix.postTranslate(pX,pY);
	float sX = 1.0f;
	float sY = 1.0f;
	matrix.postScale(sX,sY);
	final float sPX =-(pX / w) * ((sX * w) - w);
	final float sPY =-(pY / h) * ((sY * h) - h);
	matrix.postTranslate(sPX,sPY);
	return matrix;
}
```
![screenshot_2015-03-30-20-03-00](https://cloud.githubusercontent.com/assets/8722637/6900782/0078756c-d71a-11e4-98d3-844bd14bdf5f.png)
