### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,29 @@
-##1.2.0
+## 1.2.0
 
 - Added new `FastOutSlowInInterpolator`, enabled by default
 - Fixed power save mode on circular progressbar
 - Fixed animators stop on circular progressbar
 
-##1.1.0
+## 1.1.0
 
 -   Fixed Circular bugs (flashes)
 -   Added material themes (mainly for determinate support)
 -   Fixed exception bug in preview mode
 -   **/!\\** Removed a weird 48dp height in the SmoothProgressBar style
 
-##1.0.0
+## 1.0.0
 
 -   Added CircularProgressDrawable (min API 14)
 
-##0.5.1
+## 0.5.1
 
 -   Fixed bug with gradients when reversed mode enabled and mirror mode disabled
 
-##0.5.0
+## 0.5.0
 
 -   Added a gradient option via XML and JAVA
 
-##0.4.0
+## 0.4.0
 
 -   Added a `progressStart()` and `progressStop()` methods
 -   Added parameter `progressStart_activated` which makes the drawable to animate progressively at each start
@@ -32,19 +32,19 @@
 -   Added possibility to set a generated background according to the bar's colors
 -   Added a listener `progressiveStopEndedListener`: called when the progressiveStop animation is over
 
-##0.3.3
+## 0.3.3
 
 -   Added a ContentLoadingSmoothProgressBar (see also [ContentLoadingProgressBar](https://android.googlesource.com/platform/frameworks/support/+/refs/heads/master/v4/java/android/support/v4/widget/ContentLoadingProgressBar.java))
 
-##0.3.2
+## 0.3.2
 
 -   targetSdkVersion is now 14. We just need holo style.
 
-##0.3.1
+## 0.3.1
 
 -   Added a `applyStyle(int styleResId)` method
 
-##0.3.0
+## 0.3.0
 
 -   `SmoothProgressDrawable.Builder#width` is now `setStrokeWidth`
 -   The `strokeWidth` parameter is now a `float` (was an `int`)

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-##Description
+## Description
 
 Small library allowing you to make a smooth indeterminate progress bar. You can either user your progress bars and set this drawable or use directly the `SmoothProgressBarView`.
 
-##Demo:
+## Demo:
 Sample app available on the [Play Store]
 
 ![SmoothProgressBar](screenshots/SPB_sample.gif)    
 
-##How does it work
+## How does it work
 
 I wrote a [blog post] about that.
 
-##Integration     
+## Integration     
 
 **SmoothProgressBar** (min API 7): [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.castorflex.smoothprogressbar/library/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/com.github.castorflex.smoothprogressbar/library)
 
@@ -46,7 +46,7 @@ dependencies {
 
 If you really want (or have) to use Eclipse, please look at the forks.
 
-##Usage
+## Usage
 
 -	Use directly SmoothProgressBar:
 
@@ -153,7 +153,7 @@ You can also set many colors for one bar (see G+ app)
 -   programmatically (use `SmoothProgressDrawable.Builder#colors(int[])` method).
 
 
-##License
+## License
 
 ```
 Copyright 2014 Antoine Merle
@@ -171,7 +171,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-####Badges
+#### Badges
 
 Travis master: [![Build Status](https://travis-ci.org/castorflex/SmoothProgressBar.svg?branch=master)](https://travis-ci.org/castorflex/SmoothProgressBar)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
