### PR TITLE
Migrate to GradleMavenPush https://github.com/Vorlonsoft/GradleMavenPush

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,12 +5,9 @@ COMPILE_SDK_VERSION=26
 GROUP=com.github.castorflex.smoothprogressbar
 
 POM_URL=https://github.com/castorflex/SmoothProgressBar
-POM_SCM_URL=https://github.com/castorflex/SmoothProgressBar
 POM_SCM_CONNECTION=scm:git@github.com:castorflex/SmoothProgressBar.git
-POM_SCM_DEV_CONNECTION=scm:git@github.com:castorflex/SmoothProgressBar.git
 POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
-POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=castorflex
 POM_DEVELOPER_NAME=Antoine Merle
-
+POM_DEVELOPER_EMAIL=merle.antoine@gmail.com

--- a/library-circular/build.gradle
+++ b/library-circular/build.gradle
@@ -20,4 +20,4 @@ dependencies {
     implementation libraries.annotations
 }
 
-//apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
+//apply from: 'https://raw.github.com/Vorlonsoft/GradleMavenPush/master/maven-push.gradle'

--- a/library-circular/gradle.properties
+++ b/library-circular/gradle.properties
@@ -1,6 +1,5 @@
 POM_NAME=CircularProgressBar Library
 POM_ARTIFACT_ID=library-circular
-POM_PACKAGING=aar
 POM_DESCRIPTION=Android Library to make smooth circular indeterminate progress bars
 
 VERSION_NAME=1.3.0

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,4 +20,4 @@ dependencies {
     implementation libraries.annotations
 }
 
-//apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
+//apply from: 'https://raw.github.com/Vorlonsoft/GradleMavenPush/master/maven-push.gradle'

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -1,6 +1,5 @@
 POM_NAME=SmoothProgressBar Library
 POM_ARTIFACT_ID=library
-POM_PACKAGING=aar
 POM_DESCRIPTION=Android Library make smooth horizontal indeterminate progress bars
 
 VERSION_NAME=1.2.0-SNAPSHOT


### PR DESCRIPTION
Migrate to GradleMavenPush https://github.com/Vorlonsoft/GradleMavenPush

Reasons: 
- Old plugin don't have updates for 4 years
- Better javadocs generation
- Better pom file generation
- Smaller gradle.properties
- You can easy migrate from Maven Central to JCenter by adding to your code `IS_JCENTER = true` only and register at https://bintray.com/bintray/jcenter