### PR TITLE
Use AndroidX

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
         mavenCentral()
         mavenLocal()
         maven { url 'https://maven.google.com' }
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0-beta3'
@@ -24,7 +25,7 @@ allprojects {
 
 ext {
     libraries = [
-            annotations: "com.android.support:support-annotations:26.0.1"
+            annotations: "androidx.annotation:annotation:1.1.0"
     ]
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,4 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=castorflex
 POM_DEVELOPER_NAME=Antoine Merle
 
+android.useAndroidX=true

--- a/library-circular/src/main/java/fr.castorflex.android.circularprogressbar/CircularProgressDrawable.java
+++ b/library-circular/src/main/java/fr.castorflex.android.circularprogressbar/CircularProgressDrawable.java
@@ -11,14 +11,15 @@ import android.graphics.RectF;
 import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
 import android.os.PowerManager;
-import android.support.annotation.IntDef;
-import android.support.annotation.NonNull;
-import android.support.annotation.UiThread;
 import android.view.animation.Interpolator;
 import android.view.animation.LinearInterpolator;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+
+import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
+import androidx.annotation.UiThread;
 
 import static fr.castorflex.android.circularprogressbar.Utils.checkAngle;
 import static fr.castorflex.android.circularprogressbar.Utils.checkColors;

--- a/library-circular/src/main/java/fr.castorflex.android.circularprogressbar/DefaultDelegate.java
+++ b/library-circular/src/main/java/fr.castorflex.android.circularprogressbar/DefaultDelegate.java
@@ -5,9 +5,10 @@ import android.animation.ArgbEvaluator;
 import android.animation.ValueAnimator;
 import android.graphics.Canvas;
 import android.graphics.Paint;
-import android.support.annotation.NonNull;
 import android.view.animation.Interpolator;
 import android.view.animation.LinearInterpolator;
+
+import androidx.annotation.NonNull;
 
 import static fr.castorflex.android.circularprogressbar.Utils.getAnimatedFraction;
 

--- a/library-circular/src/main/java/fr.castorflex.android.circularprogressbar/PBDelegate.java
+++ b/library-circular/src/main/java/fr.castorflex.android.circularprogressbar/PBDelegate.java
@@ -2,8 +2,8 @@ package fr.castorflex.android.circularprogressbar;
 
 import android.graphics.Canvas;
 import android.graphics.Paint;
-import android.graphics.RectF;
-import android.support.annotation.UiThread;
+
+import androidx.annotation.UiThread;
 
 interface PBDelegate {
 

--- a/library-circular/src/main/java/fr.castorflex.android.circularprogressbar/PowerSaveModeDelegate.java
+++ b/library-circular/src/main/java/fr.castorflex.android.circularprogressbar/PowerSaveModeDelegate.java
@@ -3,9 +3,10 @@ package fr.castorflex.android.circularprogressbar;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.os.SystemClock;
-import android.support.annotation.NonNull;
 
 import java.util.concurrent.TimeUnit;
+
+import androidx.annotation.NonNull;
 
 /**
  * Created by castorflex on 9/12/15.

--- a/library-circular/src/main/java/fr.castorflex.android.circularprogressbar/SimpleAnimatorListener.java
+++ b/library-circular/src/main/java/fr.castorflex.android.circularprogressbar/SimpleAnimatorListener.java
@@ -1,7 +1,8 @@
 package fr.castorflex.android.circularprogressbar;
 
 import android.animation.Animator;
-import android.support.annotation.CallSuper;
+
+import androidx.annotation.CallSuper;
 
 abstract class SimpleAnimatorListener implements Animator.AnimatorListener{
   private boolean mStarted = false;

--- a/library-circular/src/main/java/fr.castorflex.android.circularprogressbar/Utils.java
+++ b/library-circular/src/main/java/fr.castorflex.android.circularprogressbar/Utils.java
@@ -5,9 +5,10 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
 import android.os.PowerManager;
-import android.support.annotation.NonNull;
 
 import java.util.Locale;
+
+import androidx.annotation.NonNull;
 
 import static java.lang.Math.min;
 

--- a/library/src/main/java/fr/castorflex/android/smoothprogressbar/SmoothProgressDrawable.java
+++ b/library/src/main/java/fr/castorflex/android/smoothprogressbar/SmoothProgressDrawable.java
@@ -12,11 +12,12 @@ import android.graphics.Shader;
 import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
 import android.os.SystemClock;
-import android.support.annotation.UiThread;
 import android.view.animation.AccelerateInterpolator;
 import android.view.animation.Interpolator;
 
 import java.util.Locale;
+
+import androidx.annotation.UiThread;
 
 import static fr.castorflex.android.smoothprogressbar.SmoothProgressBarUtils.checkColors;
 import static fr.castorflex.android.smoothprogressbar.SmoothProgressBarUtils.checkNotNull;


### PR DESCRIPTION
Use AndroidX, allowing users of `SmoothProgressBar` library to disable Jetifier. Fixes #112